### PR TITLE
feat: add container-level immutability policy and legal hold

### DIFF
--- a/examples/container_data_protection/_footer.md
+++ b/examples/container_data_protection/_footer.md
@@ -1,0 +1,4 @@
+<!-- markdownlint-disable-next-line MD041 -->
+## Data Collection
+
+The software may collect information about you and your use of the software and send it to Microsoft. Microsoft may use this information to provide services and improve our products and services. You may turn off the telemetry as described in the repository. There are also some features in the software that may enable you and Microsoft to collect data from users of your applications. If you use these features, you must comply with applicable law, including providing appropriate notices to users of your applications together with a copy of Microsoft's privacy statement. Our privacy statement is located at <https://go.microsoft.com/fwlink/?LinkID=824704>. You can learn more about data collection and use in the help documentation and our privacy statement. Your use of the software operates as your consent to these practices.

--- a/examples/container_data_protection/_header.md
+++ b/examples/container_data_protection/_header.md
@@ -1,7 +1,19 @@
 # Container data protection example
 
-This deploys the module with container-level data protection features:
-- A 30-day time-based immutability policy in `Unlocked` state
-- A legal hold on a separate container
+This example demonstrates container-level data protection features of the storage account module.
 
-> **Note:** Legal hold is applied via a `setLegalHold` POST action on create/update. Removing `legal_hold` from configuration does **not** automatically clear the hold — you must call `clearLegalHold` manually (e.g., via Azure CLI) before deleting a container under legal hold.
+**ARM Resource Types used:**
+
+- `Microsoft.Storage/storageAccounts/blobServices/containers@2025-06-01`
+- `Microsoft.Storage/storageAccounts/blobServices/containers/immutabilityPolicies@2025-06-01`
+- `Microsoft.Storage/storageAccounts/blobServices/containers` — `setLegalHold` action
+
+## What this example deploys
+
+- A storage account with two containers:
+  - `compliance-data` — protected by a 30-day time-based immutability policy in `Unlocked` state
+  - `legal-evidence` — protected by a legal hold with two tags
+
+> **Note:** Legal hold is applied via a `setLegalHold` POST action. Removing `legal_hold` from configuration does **not** automatically clear the hold — you must call `clearLegalHold` manually (e.g., via Azure CLI) before deleting a container under legal hold.
+>
+> Transitioning an immutability policy to `Locked` state is irreversible and must be performed as a separate action outside this module.

--- a/examples/container_data_protection/_header.md
+++ b/examples/container_data_protection/_header.md
@@ -1,0 +1,7 @@
+# Container data protection example
+
+This deploys the module with container-level data protection features:
+- A 30-day time-based immutability policy in `Unlocked` state
+- A legal hold on a separate container
+
+> **Note:** Legal hold is applied via a `setLegalHold` POST action on create/update. Removing `legal_hold` from configuration does **not** automatically clear the hold — you must call `clearLegalHold` manually (e.g., via Azure CLI) before deleting a container under legal hold.

--- a/examples/container_data_protection/main.tf
+++ b/examples/container_data_protection/main.tf
@@ -53,17 +53,17 @@ module "this" {
   parent_id = azapi_resource.resource_group.id
 
   containers = {
-    immutable = {
-      name = "immutable-${random_string.this.result}"
+    compliance = {
+      name = "compliance-data-${random_string.this.result}"
       immutability_policy = {
         period_since_creation_in_days = 30
         state                         = "Unlocked"
       }
     }
-    legalhold = {
-      name = "legalhold-${random_string.this.result}"
+    legal = {
+      name = "legal-evidence-${random_string.this.result}"
       legal_hold = {
-        tags = ["audit2024", "compliancehold"]
+        tags = ["case2024", "audithold"]
       }
     }
   }

--- a/examples/container_data_protection/main.tf
+++ b/examples/container_data_protection/main.tf
@@ -1,0 +1,70 @@
+terraform {
+  required_version = ">= 1.10.0"
+
+  required_providers {
+    azapi = {
+      source  = "Azure/azapi"
+      version = "~> 2.8"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.5.0, < 4.0.0"
+    }
+  }
+}
+
+provider "azapi" {}
+
+locals {
+  test_regions = ["eastus", "eastus2", "westus2", "westus3"]
+}
+
+data "azapi_client_config" "current" {}
+
+resource "random_integer" "region_index" {
+  max = length(local.test_regions) - 1
+  min = 0
+}
+
+resource "random_string" "this" {
+  length  = 6
+  special = false
+  upper   = false
+}
+
+module "naming" {
+  source  = "Azure/naming/azurerm"
+  version = "0.4.0"
+}
+
+resource "azapi_resource" "resource_group" {
+  location               = local.test_regions[random_integer.region_index.result]
+  name                   = module.naming.resource_group.name_unique
+  parent_id              = "/subscriptions/${data.azapi_client_config.current.subscription_id}"
+  type                   = "Microsoft.Resources/resourceGroups@2025-04-01"
+  response_export_values = []
+}
+
+module "this" {
+  source = "../.."
+
+  location  = azapi_resource.resource_group.location
+  name      = module.naming.storage_account.name_unique
+  parent_id = azapi_resource.resource_group.id
+
+  containers = {
+    immutable = {
+      name = "immutable-${random_string.this.result}"
+      immutability_policy = {
+        period_since_creation_in_days = 30
+        state                         = "Unlocked"
+      }
+    }
+    legalhold = {
+      name = "legalhold-${random_string.this.result}"
+      legal_hold = {
+        tags = ["audit2024", "compliancehold"]
+      }
+    }
+  }
+}

--- a/examples/container_data_protection/outputs.tf
+++ b/examples/container_data_protection/outputs.tf
@@ -1,0 +1,10 @@
+output "containers" {
+  description = "The containers created with data protection policies."
+  value       = module.this.containers
+}
+
+output "resource" {
+  description = "The storage account resource."
+  sensitive   = true
+  value       = module.this.resource
+}

--- a/main.containers.tf
+++ b/main.containers.tf
@@ -2,19 +2,22 @@ module "containers" {
   source   = "./modules/container"
   for_each = var.containers
 
-  name                                      = each.value.name
-  storage_account_id                        = azapi_resource.this.id
-  default_encryption_scope                  = each.value.default_encryption_scope
-  deny_encryption_scope_override            = each.value.deny_encryption_scope_override
-  enable_nfs_v3_all_squash                  = each.value.enable_nfs_v3_all_squash
-  enable_nfs_v3_root_squash                 = each.value.enable_nfs_v3_root_squash
-  immutable_storage_with_versioning         = each.value.immutable_storage_with_versioning
-  metadata                                  = each.value.metadata
-  public_access                             = each.value.public_access
-  resource_type                             = var.resource_types.blob_container
-  retry                                     = var.retry
-  role_assignment_definition_lookup_enabled = var.role_assignment_definition_lookup_enabled
-  role_assignments                          = each.value.role_assignments
-  timeouts                                  = each.value.timeouts != null ? each.value.timeouts : var.timeouts
-  tracing_tags_header                       = var.enable_telemetry ? local.avm_azapi_header : null
+  name                                        = each.value.name
+  storage_account_id                          = azapi_resource.this.id
+  container_immutability_policy_resource_type = var.resource_types.container_immutability_policy
+  default_encryption_scope                    = each.value.default_encryption_scope
+  deny_encryption_scope_override              = each.value.deny_encryption_scope_override
+  enable_nfs_v3_all_squash                    = each.value.enable_nfs_v3_all_squash
+  enable_nfs_v3_root_squash                   = each.value.enable_nfs_v3_root_squash
+  immutability_policy                         = each.value.immutability_policy
+  immutable_storage_with_versioning           = each.value.immutable_storage_with_versioning
+  legal_hold                                  = each.value.legal_hold
+  metadata                                    = each.value.metadata
+  public_access                               = each.value.public_access
+  resource_type                               = var.resource_types.blob_container
+  retry                                       = var.retry
+  role_assignment_definition_lookup_enabled   = var.role_assignment_definition_lookup_enabled
+  role_assignments                            = each.value.role_assignments
+  timeouts                                    = each.value.timeouts != null ? each.value.timeouts : var.timeouts
+  tracing_tags_header                         = var.enable_telemetry ? local.avm_azapi_header : null
 }

--- a/modules/container/_header.md
+++ b/modules/container/_header.md
@@ -3,3 +3,16 @@
 
 This is an internal submodule used by `terraform-azurerm-avm-res-storage-storageaccount`. Consumers MUST NOT call this submodule directly. Refer to the root module for supported inputs.
 
+**ARM Resource Type**: `Microsoft.Storage/storageAccounts/blobServices/containers@2025-06-01`
+
+## Features
+
+- Public access control (`None`, `Blob`, `Container`)
+- Container metadata
+- Default encryption scope
+- Immutable storage with versioning (container-level WORM)
+- Time-based immutability policy with `Unlocked`/`Locked` state management
+- Legal hold via `setLegalHold` POST action
+- NFSv3 all/root squash settings
+- Role assignments at container level
+

--- a/modules/container/locals.tf
+++ b/modules/container/locals.tf
@@ -8,5 +8,10 @@ locals {
     enableNfsV3RootSquash          = var.enable_nfs_v3_root_squash
     immutableStorageWithVersioning = var.immutable_storage_with_versioning
   }
+  immutability_policy_body = var.immutability_policy == null ? null : {
+    immutabilityPeriodSinceCreationInDays = var.immutability_policy.period_since_creation_in_days
+    allowProtectedAppendWrites            = var.immutability_policy.allow_protected_append_writes
+    allowProtectedAppendWritesAll         = var.immutability_policy.allow_protected_append_writes_all
+  }
   tracing_headers = var.tracing_tags_header == null ? null : { "User-Agent" = var.tracing_tags_header }
 }

--- a/modules/container/main.tf
+++ b/modules/container/main.tf
@@ -24,6 +24,51 @@ resource "azapi_resource" "this" {
   }
 }
 
+resource "azapi_resource" "immutability_policy" {
+  count = var.immutability_policy != null ? 1 : 0
+
+  name      = "default"
+  parent_id = azapi_resource.this.id
+  type      = var.container_immutability_policy_resource_type
+  body = {
+    properties = {
+      immutabilityPeriodSinceCreationInDays = var.immutability_policy.period_since_creation_in_days
+      allowProtectedAppendWrites            = var.immutability_policy.allow_protected_append_writes
+      allowProtectedAppendWritesAll         = var.immutability_policy.allow_protected_append_writes_all
+    }
+  }
+  create_headers         = local.tracing_headers
+  delete_headers         = local.tracing_headers
+  read_headers           = local.tracing_headers
+  response_export_values = []
+  retry                  = var.retry
+  update_headers         = local.tracing_headers
+
+  dynamic "timeouts" {
+    for_each = var.timeouts == null ? [] : [var.timeouts]
+
+    content {
+      create = timeouts.value.create
+      delete = timeouts.value.delete
+      read   = timeouts.value.read
+      update = timeouts.value.update
+    }
+  }
+}
+
+resource "azapi_resource_action" "legal_hold_set" {
+  count = var.legal_hold != null ? 1 : 0
+
+  resource_id = azapi_resource.this.id
+  type        = var.resource_type
+  action      = "setLegalHold"
+  method      = "POST"
+  body = {
+    tags = var.legal_hold.tags
+  }
+  retry = var.retry
+}
+
 module "role_assignments" {
   # tflint-ignore: required_module_source_tffr1 # relative source is intentional: this is an in-module composition of the role_assignments submodule
   source = "../role_assignments"

--- a/modules/container/main.tf
+++ b/modules/container/main.tf
@@ -31,11 +31,7 @@ resource "azapi_resource" "immutability_policy" {
   parent_id = azapi_resource.this.id
   type      = var.container_immutability_policy_resource_type
   body = {
-    properties = {
-      immutabilityPeriodSinceCreationInDays = var.immutability_policy.period_since_creation_in_days
-      allowProtectedAppendWrites            = var.immutability_policy.allow_protected_append_writes
-      allowProtectedAppendWritesAll         = var.immutability_policy.allow_protected_append_writes_all
-    }
+    properties = local.immutability_policy_body
   }
   create_headers         = local.tracing_headers
   delete_headers         = local.tracing_headers

--- a/modules/container/variables.tf
+++ b/modules/container/variables.tf
@@ -10,6 +10,13 @@ variable "storage_account_id" {
   nullable    = false
 }
 
+variable "container_immutability_policy_resource_type" {
+  type        = string
+  default     = "Microsoft.Storage/storageAccounts/blobServices/containers/immutabilityPolicies@2025-06-01"
+  description = "(Optional) Override the AzAPI resource type for container immutability policies."
+  nullable    = false
+}
+
 variable "default_encryption_scope" {
   type        = string
   default     = null
@@ -43,6 +50,38 @@ variable "immutable_storage_with_versioning" {
 (Optional) Configures container-level immutability with version-level WORM. Defaults to `null` (immutability disabled).
 
 - `enabled` - (Required) Whether immutable storage with versioning is enabled.
+EOT
+}
+
+variable "immutability_policy" {
+  type = object({
+    allow_protected_append_writes     = optional(bool)
+    allow_protected_append_writes_all = optional(bool)
+    period_since_creation_in_days     = number
+    state                             = optional(string, "Unlocked")
+  })
+  default     = null
+  description = <<-EOT
+(Optional) A time-based immutability policy for the container. Defaults to `null`.
+
+- `period_since_creation_in_days` - (Required) The immutability period in days.
+- `state` - (Optional) `Unlocked` (can increase or decrease) or `Locked` (can only increase, irreversible). Defaults to `Unlocked`. Note: transitioning to `Locked` is irreversible and must be done manually via `azapi_resource_action` — this module manages the policy in `Unlocked` state only.
+- `allow_protected_append_writes` - (Optional) Allow appending to append blobs while under immutability. Defaults to `null`.
+- `allow_protected_append_writes_all` - (Optional) Allow appending to block and append blobs. Defaults to `null`.
+EOT
+}
+
+variable "legal_hold" {
+  type = object({
+    tags = list(string)
+  })
+  default     = null
+  description = <<-EOT
+(Optional) A legal hold placed on the container. Defaults to `null`.
+
+- `tags` - (Required) A list of legal hold tags. Each tag must be alphanumeric and 3–23 characters long.
+
+> **Note:** Legal hold is applied via a `setLegalHold` POST action. Clearing the hold on destroy is not supported by this module — removing `legal_hold` from configuration will NOT automatically call `clearLegalHold`. To remove a legal hold, call `clearLegalHold` manually (e.g., via Azure CLI or a one-off `azapi_resource_action`).
 EOT
 }
 

--- a/variables.container.tf
+++ b/variables.container.tf
@@ -16,6 +16,15 @@ variable "containers" {
     immutable_storage_with_versioning = optional(object({
       enabled = bool
     }))
+    immutability_policy = optional(object({
+      allow_protected_append_writes     = optional(bool)
+      allow_protected_append_writes_all = optional(bool)
+      period_since_creation_in_days     = number
+      state                             = optional(string, "Unlocked")
+    }))
+    legal_hold = optional(object({
+      tags = list(string)
+    }))
 
     role_assignments = optional(map(object({
       role_definition_id_or_name             = string
@@ -48,6 +57,13 @@ A map of containers to create on the storage account. The map key is arbitrary; 
 - `enable_nfs_v3_root_squash` - (Optional) Enable NFSv3 root squash (only valid for NFSv3 enabled accounts). Defaults to `null`.
 - `immutable_storage_with_versioning` - (Optional) Configures container-level immutability with version-level WORM. Defaults to `null`. Supports:
   - `enabled` - (Required) Whether immutable storage with versioning is enabled.
+- `immutability_policy` - (Optional) A time-based immutability policy for the container. Defaults to `null`.
+  - `period_since_creation_in_days` - (Required) The immutability period in days.
+  - `state` - (Optional) Policy state. `Unlocked` (default, allows increases/decreases) or `Locked` (allows only increases, irreversible).
+  - `allow_protected_append_writes` - (Optional) Allow new blocks to be written to append blobs. Defaults to `null`.
+  - `allow_protected_append_writes_all` - (Optional) Allow new blocks to be written to both block and append blobs. Defaults to `null`.
+- `legal_hold` - (Optional) A legal hold for the container. Defaults to `null`.
+  - `tags` - (Required) A list of legal hold tags. Each tag must be alphanumeric, 3–23 chars.
 - `role_assignments` - (Optional) A map of role assignments to create on the container. Defaults to `{}`. See `var.role_assignments` for the attribute schema.
 - `timeouts` - (Optional) Per-operation timeouts for the container resource. Defaults to `null` (uses provider defaults inherited from `var.timeouts`). Supports:
   - `create` - (Optional) Timeout for create operations.

--- a/variables.container.tf
+++ b/variables.container.tf
@@ -64,12 +64,42 @@ A map of containers to create on the storage account. The map key is arbitrary; 
   - `allow_protected_append_writes_all` - (Optional) Allow new blocks to be written to both block and append blobs. Defaults to `null`.
 - `legal_hold` - (Optional) A legal hold for the container. Defaults to `null`.
   - `tags` - (Required) A list of legal hold tags. Each tag must be alphanumeric, 3–23 chars.
-- `role_assignments` - (Optional) A map of role assignments to create on the container. Defaults to `{}`. See `var.role_assignments` for the attribute schema.
+  > **Note:** Legal hold is applied via a `setLegalHold` POST action. Removing `legal_hold` from configuration does NOT automatically call `clearLegalHold` — clearing requires manual intervention.
+- `role_assignments` - (Optional) A map of role assignments to create on the container. Defaults to `{}`. Each entry supports:
+  - `role_definition_id_or_name` - (Required) The role definition ID or name.
+  - `principal_id` - (Required) The principal ID to assign the role to.
+  - `description` - (Optional) Description of the role assignment.
+  - `skip_service_principal_aad_check` - (Optional) Skip the Azure Active Directory check for service principals. Defaults to `false`.
+  - `condition` - (Optional) The condition expression limiting the resources the role can be assigned to.
+  - `condition_version` - (Optional) The condition version.
+  - `delegated_managed_identity_resource_id` - (Optional) The delegated Azure Resource Id containing a Managed Identity.
+  - `principal_type` - (Optional) The type of principal (`User`, `Group`, `ServicePrincipal`).
 - `timeouts` - (Optional) Per-operation timeouts for the container resource. Defaults to `null` (uses provider defaults inherited from `var.timeouts`). Supports:
-  - `create` - (Optional) Timeout for create operations.
-  - `delete` - (Optional) Timeout for delete operations.
-  - `read` - (Optional) Timeout for read operations.
-  - `update` - (Optional) Timeout for update operations.
+  - `create` - (Optional) Timeout for create operations. Defaults to 30 minutes.
+  - `delete` - (Optional) Timeout for delete operations. Defaults to 30 minutes.
+  - `read` - (Optional) Timeout for read operations. Defaults to 5 minutes.
+  - `update` - (Optional) Timeout for update operations. Defaults to 30 minutes.
+
+Example:
+
+```terraform
+containers = {
+  compliance = {
+    name          = "compliance-data"
+    public_access = "None"
+    immutability_policy = {
+      period_since_creation_in_days = 30
+      state                         = "Unlocked"
+    }
+  }
+  legal = {
+    name = "legal-evidence"
+    legal_hold = {
+      tags = ["case2024", "audithold"]
+    }
+  }
+}
+```
 EOT
   nullable    = false
 }

--- a/variables.tf
+++ b/variables.tf
@@ -177,35 +177,37 @@ variable "private_endpoints_manage_dns_zone_group" {
 
 variable "resource_types" {
   type = object({
-    storage_account            = optional(string, "Microsoft.Storage/storageAccounts@2025-06-01")
-    customer_managed_key_vault = optional(string, "Microsoft.KeyVault/vaults@2024-11-01")
-    lock                       = optional(string, "Microsoft.Authorization/locks@2020-05-01")
-    blob_container             = optional(string, "Microsoft.Storage/storageAccounts/blobServices/containers@2025-06-01")
-    blob_service               = optional(string, "Microsoft.Storage/storageAccounts/blobServices@2025-06-01")
-    queue                      = optional(string, "Microsoft.Storage/storageAccounts/queueServices/queues@2025-06-01")
-    table                      = optional(string, "Microsoft.Storage/storageAccounts/tableServices/tables@2025-06-01")
-    share                      = optional(string, "Microsoft.Storage/storageAccounts/fileServices/shares@2025-06-01")
-    local_user                 = optional(string, "Microsoft.Storage/storageAccounts/localUsers@2025-06-01")
-    management_policy          = optional(string, "Microsoft.Storage/storageAccounts/managementPolicies@2025-06-01")
-    private_endpoint           = optional(string, "Microsoft.Network/privateEndpoints@2025-05-01")
-    private_dns_zone_group     = optional(string, "Microsoft.Network/privateEndpoints/privateDnsZoneGroups@2025-05-01")
+    storage_account               = optional(string, "Microsoft.Storage/storageAccounts@2025-06-01")
+    customer_managed_key_vault    = optional(string, "Microsoft.KeyVault/vaults@2024-11-01")
+    lock                          = optional(string, "Microsoft.Authorization/locks@2020-05-01")
+    blob_container                = optional(string, "Microsoft.Storage/storageAccounts/blobServices/containers@2025-06-01")
+    blob_service                  = optional(string, "Microsoft.Storage/storageAccounts/blobServices@2025-06-01")
+    container_immutability_policy = optional(string, "Microsoft.Storage/storageAccounts/blobServices/containers/immutabilityPolicies@2025-06-01")
+    queue                         = optional(string, "Microsoft.Storage/storageAccounts/queueServices/queues@2025-06-01")
+    table                         = optional(string, "Microsoft.Storage/storageAccounts/tableServices/tables@2025-06-01")
+    share                         = optional(string, "Microsoft.Storage/storageAccounts/fileServices/shares@2025-06-01")
+    local_user                    = optional(string, "Microsoft.Storage/storageAccounts/localUsers@2025-06-01")
+    management_policy             = optional(string, "Microsoft.Storage/storageAccounts/managementPolicies@2025-06-01")
+    private_endpoint              = optional(string, "Microsoft.Network/privateEndpoints@2025-05-01")
+    private_dns_zone_group        = optional(string, "Microsoft.Network/privateEndpoints/privateDnsZoneGroups@2025-05-01")
   })
   default     = {}
   description = <<DESCRIPTION
 Override the AzAPI `<provider>/<resource>@<api-version>` strings used by this module. Each key defaults to a tested value; supply only the keys you want to override. Useful when targeting a sovereign cloud with older API versions, or when opting into a newer preview API.
 
-- `storage_account`            - The storage account itself, used by both the create call and the customer-managed-key patch.
-- `customer_managed_key_vault` - The Key Vault data source used to look up the vault URI when CMK is enabled.
-- `lock`                       - Management lock applied to the storage account (and to private endpoints when configured).
-- `blob_container`             - Blob containers (also used by Data Lake Gen2 filesystems, which are blob containers in ARM).
-- `blob_service`               - The `blobServices/default` sub-resource, patched by the static-website submodule.
-- `queue`                      - Storage queues.
-- `table`                      - Storage tables.
-- `share`                      - File shares.
-- `local_user`                 - SFTP local users.
-- `management_policy`          - The lifecycle-management policy.
-- `private_endpoint`           - Private endpoints created for the storage account.
-- `private_dns_zone_group`     - The private DNS zone group resource attached to a private endpoint.
+- `storage_account`                       - The storage account itself, used by both the create call and the customer-managed-key patch.
+- `customer_managed_key_vault`            - The Key Vault data source used to look up the vault URI when CMK is enabled.
+- `lock`                                  - Management lock applied to the storage account (and to private endpoints when configured).
+- `blob_container`                        - Blob containers (also used by Data Lake Gen2 filesystems, which are blob containers in ARM).
+- `blob_service`                          - The `blobServices/default` sub-resource, patched by the static-website submodule.
+- `container_immutability_policy`         - The immutability policy sub-resource of a blob container.
+- `queue`                                 - Storage queues.
+- `table`                                 - Storage tables.
+- `share`                                 - File shares.
+- `local_user`                            - SFTP local users.
+- `management_policy`                     - The lifecycle-management policy.
+- `private_endpoint`                      - Private endpoints created for the storage account.
+- `private_dns_zone_group`                - The private DNS zone group resource attached to a private endpoint.
 DESCRIPTION
   nullable    = false
 }


### PR DESCRIPTION
## Summary

Adds container-level data protection features: time-based immutability policies and legal holds.

## Changes

- Extended `var.containers[*]` in `variables.container.tf` with optional `immutability_policy` and `legal_hold` fields
- Updated `main.containers.tf` to pass new fields to the container submodule
- Added `container_immutability_policy` to `var.resource_types` in `variables.tf`
- Updated `modules/container/variables.tf` with new variables
- Added `azapi_resource.immutability_policy` and `azapi_resource_action.legal_hold_set` to `modules/container/main.tf`
- New example: `examples/container_data_protection/`

## Features

- Per-container time-based immutability policy (`Unlocked` or `Locked` state)
- Per-container legal hold (set via `setLegalHold` POST action)

## Known Limitation

Legal hold `clearLegalHold` is not called on destroy — documented in the variable description. Manual intervention required to clear a legal hold before destroying a container.